### PR TITLE
Remove COV-19 specific advanced filters

### DIFF
--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -64,23 +64,23 @@ export const advancedFilterOptions = [
     tooltip:
       'This filter will return monitorees that have texted “STOP” in response to a Sara Alert text message and cannot receive messages through SMS Preferred Reporting Methods until they text "START".'
   },
-  {
-    name: 'seven-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
-    description:
-      'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
-  },
-  {
-    name: 'ten-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
-    description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
-  },
+  // {
+  //   name: 'seven-day-quarantine',
+  //   title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
+  //   description:
+  //     'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
+  //   type: 'boolean',
+  //   tooltip:
+  //     'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
+  // },
+  // {
+  //   name: 'ten-day-quarantine',
+  //   title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
+  //   description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
+  //   type: 'boolean',
+  //   tooltip:
+  //     'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
+  // },
 
   /* SEARCH FILTER OPTIONS */
   {


### PR DESCRIPTION
# Description

Write out a concise summary of this pull request and what it addresses.

## (Bugfix) How to Replicate
When selecting advanced filters, `Candidate to Reduce Quarantine after 7 Days (Boolean)` and `Candidate to Reduce Quarantine after 10 Days (Boolean)` are still present. 

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`advancedFilterOptions.js`
- Commented out COVID-19 quarantine specific filters. 

